### PR TITLE
FOLIO-1609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <ramlfiles_util_path>${basedir}/raml-util</ramlfiles_util_path>
     <raml-module-builder.version>19.4.1</raml-module-builder.version>
-    <vertx-version>3.5.3</vertx-version>
+    <vertx-version>3.5.4</vertx-version>
     <rest-assured.version>3.1.1</rest-assured.version>
   </properties>
 
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.7.3</version>
+      <version>2.8.11.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,18 @@
           <localCheckout>true</localCheckout>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
+               https://issues.folio.org/browse/FOLIO-1609
+               https://issues.apache.org/jira/browse/SUREFIRE-1588
+          -->
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
- workaround for https://issues.apache.org/jira/browse/SUREFIRE-1588
- security fixes for vertx (update to 3.5.4) and jackson-databind (update to 2.8.11.1)