### PR TITLE
Folio 2256 kube deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ buildMvn {
   mvnDeploy = 'yes'
   publishAPI = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Enables kubeDeploy step on buildMvn pipeline to deploy container to CI kubernetes cluster on release/snapshot builds for FOLIO-2256.
