### PR TITLE
[MODPWD-24] mod-password-validator does not purge tenant data

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -42,6 +42,9 @@
         {
           "methods": ["POST"],
           "pathPattern": "/_/tenant"
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/_/tenant"
         }
       ]
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -36,7 +36,7 @@
     },
     {
       "id": "_tenant",
-      "version": "1.0",
+      "version": "1.2",
       "interfaceType": "system",
       "handlers": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <raml-module-builder.version>24.0.0</raml-module-builder.version>
     <vertx-version>3.5.4</vertx-version>
     <rest-assured.version>3.1.1</rest-assured.version>
+    <fasterxml.jackson.version>2.9.10</fasterxml.jackson.version>
   </properties>
 
 
@@ -78,27 +79,27 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.9</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9.2</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.9</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>2.9.9</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.9</version>
+      <version>${fasterxml.jackson.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- delete method was added to ModuleDescriptor, _tenant interface
- com.fasterxml.jackson.core:jackson-databind was updated to version 2.9.10