### PR TITLE
Don't force starting embedded postgres.

### DIFF
--- a/src/test/java/org/folio/rest/impl/PasswordResourceTest.java
+++ b/src/test/java/org/folio/rest/impl/PasswordResourceTest.java
@@ -86,8 +86,6 @@ public class PasswordResourceTest {
     vertx = Vertx.vertx();
     port = NetworkUtils.nextFreePort();
 
-    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-
     TenantClient tenantClient = new TenantClient(HOST + port, TENANT, TENANT);
     DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put(HTTP_PORT, port));
     vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {

--- a/src/test/java/org/folio/rest/impl/ValidatorRegistryTest.java
+++ b/src/test/java/org/folio/rest/impl/ValidatorRegistryTest.java
@@ -146,8 +146,6 @@ public class ValidatorRegistryTest {
     vertx = Vertx.vertx();
     port = NetworkUtils.nextFreePort();
 
-    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-
     TenantClient tenantClient = new TenantClient(HOST + port, "diku", null);
 
     final DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put(HTTP_PORT, port));


### PR DESCRIPTION
RMB automatically starts embedded postgres, but doesn't start it when
it already runs (for example on CI server or on developer's machine).
See https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-26