### PR TITLE
FOLSPRINGB-2 Reinstate "USER folio" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM folioci/alpine-jre-openjdk11:latest
 
+USER root
+
 # Copy your fat jar to the container
 ENV APP_FILE mod-password-validator-fat.jar
 
@@ -12,6 +14,9 @@ ARG RUN_ENV_FILE=run-env.sh
 
 COPY ${RUN_ENV_FILE} ${JAVA_APP_DIR}/
 RUN chmod 755 ${JAVA_APP_DIR}/${RUN_ENV_FILE}
+
+# Run as this user
+USER folio
 
 # Expose this port locally in the container.
 EXPOSE 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM folioci/alpine-jre-openjdk11:latest
 
-USER root
-
 # Copy your fat jar to the container
 ENV APP_FILE mod-password-validator-fat.jar
 


### PR DESCRIPTION
## Purpose
Reinstate "USER folio" in Dockerfile

## Approach
Reinstate user "folio" at the end of Dockerfile so that module runs on behalf of that user instead of "root"