### PR TITLE
MODPWD-75: 2.1.0 upgrade fails in multi-tenant environment

### DIFF
--- a/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
+++ b/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
@@ -76,8 +76,8 @@
     <changeSet id="MODPWD-64@@drop-set_validation_rules_md_json-function" author="psmahin">
         <sql dbms="postgresql">DROP FUNCTION IF EXISTS set_validation_rules_md_json</sql>
     </changeSet>
-    <changeSet id="MODPWD-64@@drop-f_unaccent-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS f_unaccent</sql>
+    <changeSet id="MODPWD-64@@drop-f_unaccent-function" author="psmahin" runOnChange="true">
+        <sql dbms="postgresql">SELECT * FROM information_schema.routines WHERE routine_name LIKE '%f_unaccent'</sql>
     </changeSet>
 
 


### PR DESCRIPTION
## Purpose
In a multi-tenant environment, the mod-password-validator-2.1.0 upgrade from v2.0.2 fails with an error like this:
`ERROR: cannot drop function f_unaccent(text) because other objects depend on it`

## Approach
Override changeSet @drop-f_unaccent-function

## Learning
[MODPWD-75](https://issues.folio.org/browse/MODPWD-75)
