### PR TITLE
MODPWD-56 Support CQL queries when getting list of validation rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-xx-xx v2.3.0-SNAPSHOT
+ * MODPWD-56 Support CQL queries when getting list of validation rules
+
 ## 2021-10-04 v2.2.0
  * MODPWD-69 Remove raml-util and update Jenkinsfile
  * MODPWD-71: Update rule documentation in README.md

--- a/src/main/java/org/folio/pv/controller/ErrorHandlingController.java
+++ b/src/main/java/org/folio/pv/controller/ErrorHandlingController.java
@@ -1,11 +1,8 @@
 package org.folio.pv.controller;
 
-import static feign.Util.UTF_8;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
-import feign.FeignException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -13,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.pv.domain.dto.Error;
 import org.folio.pv.domain.dto.Errors;
 import org.folio.pv.domain.dto.Parameter;
@@ -55,6 +53,14 @@ public class ErrorHandlingController {
     return new Error().message(exception.getMessage())
       .type(FOLIO_EXTERNAL_OR_UNDEFINED_ERROR_TYPE)
       .addParametersItem(parameter);
+  }
+
+  @ResponseBody
+  @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+  @ExceptionHandler(CQL2PgJSONException.class)
+  public Error handleException(CQL2PgJSONException exception) {
+    return new Error().message(exception.getMessage())
+      .type(FOLIO_EXTERNAL_OR_UNDEFINED_ERROR_TYPE);
   }
 
 }

--- a/src/main/java/org/folio/pv/controller/ValidationRulesController.java
+++ b/src/main/java/org/folio/pv/controller/ValidationRulesController.java
@@ -36,8 +36,8 @@ public class ValidationRulesController implements RulesApi {
 
   @Override
   public ResponseEntity<ValidationRuleCollection> getTenantRules(@Min(0) @Max(2147483647) @Valid Integer offset,
-      @Min(0) @Max(2147483647) @Valid Integer limit, @Valid String query) {
-    var validationRules = validationRuleService.getValidationRules(offset, limit, "");
+      @Min(0) @Max(2147483647) @Valid Integer limit, @Valid String cql) {
+    var validationRules = validationRuleService.getValidationRules(offset, limit, cql);
     return new ResponseEntity<>(validationRules, HttpStatus.OK);
   }
 

--- a/src/main/java/org/folio/pv/repository/ValidationRuleRepository.java
+++ b/src/main/java/org/folio/pv/repository/ValidationRuleRepository.java
@@ -1,15 +1,12 @@
 package org.folio.pv.repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.folio.pv.domain.entity.PasswordValidationRule;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.folio.spring.cql.JpaCqlRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ValidationRuleRepository extends JpaRepository<PasswordValidationRule, UUID> {
-  Optional<PasswordValidationRule> findById(UUID id);
-
+public interface ValidationRuleRepository extends JpaCqlRepository<PasswordValidationRule, UUID> {
   List<PasswordValidationRule> findByRuleState(String ruleState);
 }

--- a/src/main/java/org/folio/pv/service/ValidationRuleService.java
+++ b/src/main/java/org/folio/pv/service/ValidationRuleService.java
@@ -9,7 +9,7 @@ public interface ValidationRuleService {
 
   ValidationRule getValidationRuleById(String ruleId);
 
-  ValidationRuleCollection getValidationRules(Integer offset, Integer limit, String orderBy);
+  ValidationRuleCollection getValidationRules(Integer offset, Integer limit, String cql);
 
   ValidationRule createOrUpdateValidationRule(ValidationRule validationRule);
 

--- a/src/main/java/org/folio/pv/service/ValidationRuleServiceImpl.java
+++ b/src/main/java/org/folio/pv/service/ValidationRuleServiceImpl.java
@@ -1,5 +1,7 @@
 package org.folio.pv.service;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -50,8 +52,10 @@ public class ValidationRuleServiceImpl implements ValidationRuleService {
   }
 
   @Override
-  public ValidationRuleCollection getValidationRules(Integer offset, Integer limit, String orderBy) {
-    var validationRuleList = validationRuleRepository.findAll(new OffsetRequest(offset, limit));
+  public ValidationRuleCollection getValidationRules(Integer offset, Integer limit, String cql) {
+    var validationRuleList = isBlank(cql)
+      ? validationRuleRepository.findAll(new OffsetRequest(offset, limit))
+      : validationRuleRepository.findByCQL(cql, new OffsetRequest(offset, limit));
     return validationRuleMapper.mapEntitiesToValidationRuleCollection(validationRuleList);
   }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQL10Dialect
         format_sql: true
-    show-sql: true
+    show-sql: false
   liquibase:
     changeLog: classpath:db/changelog/changelog-master.xml
     enabled: true

--- a/src/main/resources/swagger.api/validator-registry.yaml
+++ b/src/main/resources/swagger.api/validator-registry.yaml
@@ -14,6 +14,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/validationRuleCollection"
+        '422':
+          $ref: "#/components/responses/trait_validate_422"
         '500':
           description: Internal server error
           content:

--- a/src/test/java/org/folio/pv/api/ValidationRulesControllerApiTest.java
+++ b/src/test/java/org/folio/pv/api/ValidationRulesControllerApiTest.java
@@ -2,9 +2,12 @@ package org.folio.pv.api;
 
 
 import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_UNPROCESSABLE_ENTITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import static org.folio.pv.testutils.APITestUtils.LIMIT_PARAM;
+import static org.folio.pv.testutils.APITestUtils.QUERY_PARAM;
 import static org.folio.pv.testutils.APITestUtils.rulePath;
 import static org.folio.pv.testutils.APITestUtils.rulesPath;
 import static org.folio.pv.testutils.DBTestUtils.getValidationRuleById;
@@ -14,6 +17,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import org.folio.pv.domain.dto.Error;
 import org.folio.pv.domain.dto.ValidationRule;
 import org.folio.pv.domain.dto.ValidationRuleCollection;
 
@@ -42,6 +46,16 @@ class ValidationRulesControllerApiTest extends BaseApiTest {
           "alphabetical_letters",
           "not_compromised"
         )));
+  }
+
+  @Test
+  void shouldReturn422onInvalidCql() {
+    var error = verifyGet(
+      rulesPath(LIMIT_PARAM, "100", QUERY_PARAM, "invalid"),
+      SC_UNPROCESSABLE_ENTITY
+    ).as(Error.class);
+
+    assertFalse(error.getMessage().isEmpty());
   }
 
   @Test

--- a/src/test/java/org/folio/pv/service/ValidationRuleServiceImplTest.java
+++ b/src/test/java/org/folio/pv/service/ValidationRuleServiceImplTest.java
@@ -87,7 +87,7 @@ class ValidationRuleServiceImplTest {
   }
 
   @Test
-  void shouldReturnValidationRules(@Random Integer offset, @Random Integer limit, @Random String orderBy,
+  void shouldReturnValidationRules(@Random Integer offset, @Random Integer limit, @Random String cql,
                                    @Random List<PasswordValidationRule> rules,
                                    @Random ValidationRuleCollection ruleCollection) {
 
@@ -96,10 +96,28 @@ class ValidationRuleServiceImplTest {
     OffsetRequest offsetReq = new OffsetRequest(o, l);
     Page<PasswordValidationRule> rulePage = new PageImpl<>(rules);
 
+    when(repository.findByCQL(cql, offsetReq)).thenReturn(rulePage);
+    when(mapper.mapEntitiesToValidationRuleCollection(rulePage)).thenReturn(ruleCollection);
+
+    ValidationRuleCollection result = service.getValidationRules(o, l, cql);
+
+    assertSame(ruleCollection, result);
+  }
+
+  @Test
+  void shouldReturnValidationRulesWithoutCql(@Random Integer offset, @Random Integer limit,
+                                   @Random List<PasswordValidationRule> rules,
+                                   @Random ValidationRuleCollection ruleCollection) {
+
+    var o = Math.abs(offset);
+    var l = Math.abs(limit);
+    var offsetReq = new OffsetRequest(o, l);
+    var rulePage = new PageImpl<>(rules);
+
     when(repository.findAll(offsetReq)).thenReturn(rulePage);
     when(mapper.mapEntitiesToValidationRuleCollection(rulePage)).thenReturn(ruleCollection);
 
-    ValidationRuleCollection result = service.getValidationRules(o, l, orderBy);
+    var result = service.getValidationRules(o, l, null);
 
     assertSame(ruleCollection, result);
   }
@@ -157,7 +175,7 @@ class ValidationRuleServiceImplTest {
 
   @Nested
   @ExtendWith(MockitoExtension.class)
-  class ValidatePassword {
+  class ValidatePasswordTest {
 
     private static final String INVALID_PASSWORD = "password.invalid";
 

--- a/src/test/java/org/folio/pv/testutils/APITestUtils.java
+++ b/src/test/java/org/folio/pv/testutils/APITestUtils.java
@@ -21,6 +21,7 @@ public class APITestUtils {
   public static final String PASSWORD_VALIDATE_PATH = "/password/validate";
 
   public static final String LIMIT_PARAM = "limit";
+  public static final String QUERY_PARAM = "query";
 
   public static String rulesPath(String... params) {
     if (params.length % 2 != 0) {


### PR DESCRIPTION
## Purpose
Support CQL queries when getting list of validation rules (`GET /tenant/rules`)

## Approach
- use JpaCqlRepository for rules
- update validator-registry.yaml
- cover with unit-tests

## Learning
[MODPWD-56](https://issues.folio.org/browse/MODPWD-56)
