### PR TITLE
MODPWD-84 Kiwi R3 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-xx-xx v2.3.0-SNAPSHOT
+ * MODPWD-84 Kiwi R3 2021 - Log4j vulnerability verification and correction
+
 ## 2021-10-04 v2.2.0
  * MODPWD-69 Remove raml-util and update Jenkinsfile
  * MODPWD-71: Update rule documentation in README.md

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <folio-spring-base.version>2.0.0</folio-spring-base.version>
     <openapi-generator.version>5.2.0</openapi-generator.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
+    <log4j2.version>2.16.0</log4j2.version> <!-- if less then vulnerable to CVE-2021-44228 and CVE-2021-45046-->
 
     <validator-registry.yaml.file>${project.basedir}/src/main/resources/swagger.api/validator-registry.yaml</validator-registry.yaml.file>
     <password-validator.yaml.file>${project.basedir}/src/main/resources/swagger.api/password-validator.yaml</password-validator.yaml.file>


### PR DESCRIPTION
## Purpose
Fix log4j2 `RCE` vulnerability

## Approach
- log4j2 version set to 2.16.0

## Learning
[MODPWD-84](https://issues.folio.org/browse/MODPWD-84)
[CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
[CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33)
`mvn dependency:tree | grep log4j` can be used to check log4j versions used
