### PR TITLE
Fix deployment descriptor MODPWD-88

### DIFF
--- a/descriptors/DeploymentDescriptor-template.json
+++ b/descriptors/DeploymentDescriptor-template.json
@@ -2,6 +2,6 @@
   "srvcId": "@artifactId@-@version@",
   "nodeId": "localhost",
   "descriptor": {
-    "exec": "java -Dport=%p -jar ../mod-password-validator/target/mod-password-validator-fat.jar -Dhttp.port=%p embed_postgres=true"
+    "exec": "java -Dserver.port=%p -jar ../mod-password-validator/target/@artifactId@-@version@.jar"
   }
 }


### PR DESCRIPTION
Fixing this makes it possible to deploy the module locally.

It also illustrates how the port is controlled.