### PR TITLE
MODPWD-75 mod-password-validator 2.1.0 upgrade fails in multi-tenant …

### DIFF
--- a/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
+++ b/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
@@ -11,7 +11,7 @@
         <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.rmb_internal</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb-internal-analyze-table" author="psmahin">
-        <sql dbms="postgresql">DROP TABLE IF EXISTS rmb_internal_analyze</sql>
+        <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.rmb_internal_analyze</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb-internal-index-table" author="psmahin">
         <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.rmb_internal_index</sql>

--- a/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
+++ b/src/main/resources/db/changelog/changes/v2.1.0/cleanup.xml
@@ -5,79 +5,79 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
     <changeSet id="MODPWD-64@@drop-old-validation-rules-table" author="psmahin">
-        <sql dbms="postgresql">DROP TABLE IF EXISTS validation_rules</sql>
+        <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.validation_rules</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb-internal-table" author="psmahin">
-        <sql dbms="postgresql">DROP TABLE IF EXISTS rmb_internal</sql>
+        <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.rmb_internal</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb-internal-analyze-table" author="psmahin">
         <sql dbms="postgresql">DROP TABLE IF EXISTS rmb_internal_analyze</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb-internal-index-table" author="psmahin">
-        <sql dbms="postgresql">DROP TABLE IF EXISTS rmb_internal_index</sql>
+        <sql dbms="postgresql">DROP TABLE IF EXISTS ${database.defaultSchemaName}.rmb_internal_index</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-count_estimate_smart2-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS count_estimate_smart2</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.count_estimate_smart2</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-first_array_object_value-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS first_array_object_value</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.first_array_object_value</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-normalize_digits-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS normalize_digits</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.normalize_digits</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-count_estimate-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS count_estimate</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.count_estimate</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-concat_array_object-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS concat_array_object</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.concat_array_object</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-concat_array_object_values2-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS concat_array_object_values (in jsonb_array jsonb, in field text)</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.concat_array_object_values (in jsonb_array jsonb, in field text)</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-concat_array_object_values4-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS concat_array_object_values (in jsonb_array jsonb, in field text, in filterkey text, in filtervalue text)</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.concat_array_object_values (in jsonb_array jsonb, in field text, in filterkey text, in filtervalue text)</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-tsquery_or-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS tsquery_or (in text)</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.tsquery_or (in text)</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-uuid_smaller-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS uuid_smaller CASCADE</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.uuid_smaller CASCADE</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-count_estimate_default-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS count_estimate_default</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.count_estimate_default</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-next_uuid-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS next_uuid</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.next_uuid</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-uuid_larger-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS uuid_larger CASCADE</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.uuid_larger CASCADE</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-tsquery_phrase-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS tsquery_phrase (in text)</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.tsquery_phrase (in text)</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-get_tsvector-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS get_tsvector</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.get_tsvector</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-rmb_internal_index-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS rmb_internal_index</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.rmb_internal_index</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-tsquery_and-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS tsquery_and (in text)</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.tsquery_and (in text)</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-concat_space_sql-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS concat_space_sql</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.concat_space_sql</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-set_id_in_jsonb-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS set_id_in_jsonb</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_id_in_jsonb</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-validation_rules_set_md-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS validation_rules_set_md</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.validation_rules_set_md</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-set_validation_rules_md_json-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS set_validation_rules_md_json</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.set_validation_rules_md_json</sql>
     </changeSet>
     <changeSet id="MODPWD-64@@drop-f_unaccent-function" author="psmahin">
-        <sql dbms="postgresql">DROP FUNCTION IF EXISTS f_unaccent</sql>
+        <sql dbms="postgresql">DROP FUNCTION IF EXISTS ${database.defaultSchemaName}.f_unaccent</sql>
     </changeSet>
 
 


### PR DESCRIPTION
### Purpose
mod-password-validator 2.1.0 upgrade fails in multi-tenant environment

### Approach
Update RMB-cleanup scripts with specifying the schema. This is possible with ${database.defaultSchemaName}

### Learning
https://issues.folio.org/browse/MODPWD-75