### PR TITLE
MODPWD-93: Spring4Shell (CVE-2022-22965)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.3</version>
+    <version>2.6.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
Update Spring from 2.6.3 to 2.6.6.

This fixes these vulnerabilities:

* Spring4Shell spring-beans RCE https://nvd.nist.gov/vuln/detail/CVE-2022-22965
* PostgreSQL Arbitrary Code Injection https://nvd.nist.gov/vuln/detail/CVE-2022-26520
* PostgreSQL RCE https://nvd.nist.gov/vuln/detail/CVE-2022-21724
* jackson-databind DoS https://nvd.nist.gov/vuln/detail/CVE-2020-36518
* liquibase-core XML External Entity (XXE) Injection https://nvd.nist.gov/vuln/detail/CVE-2022-0839