### PR TITLE
MODPWD-113: Migrate to folio-spring-support v7.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## v3.1.0 in progress
+### Dependencies
+* Bump `folio-spring-base` from `6.0.1` to `7.0.0`
+* Add  `folio-spring-cql` with groupId `org.folio` & version `7.0.0`
+
+### Tech Dept
+* Migrate to folio-spring-support v7.0.0 ([MODPWD-113](https://issues.folio.org/browse/MODPWD-113))
+
 ## v3.0.0 2023-02-15
 ### Breaking changes
 * Migration to Spring Boot v3.0.0 and Java 17 ([MODPWD-110](https://issues.folio.org/browse/MODPWD-110))

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <validator-registry.yaml.file>${project.basedir}/src/main/resources/swagger.api/validator-registry.yaml</validator-registry.yaml.file>
     <password-validator.yaml.file>${project.basedir}/src/main/resources/swagger.api/password-validator.yaml</password-validator.yaml.file>
 
-    <folio-spring-base.version>6.0.1</folio-spring-base.version>
+    <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <hypersistence-utils.version>3.1.2</hypersistence-utils.version>
 
@@ -54,6 +54,11 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
+      <version>${folio-spring-base.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-cql</artifactId>
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/pv/service/ValidationRuleServiceImpl.java
+++ b/src/main/java/org/folio/pv/service/ValidationRuleServiceImpl.java
@@ -59,7 +59,7 @@ public class ValidationRuleServiceImpl implements ValidationRuleService {
 
     var validationRuleList = isBlank
       ? validationRuleRepository.findAll(new OffsetRequest(offset, limit))
-      : validationRuleRepository.findByCQL(cql, new OffsetRequest(offset, limit));
+      : validationRuleRepository.findByCql(cql, new OffsetRequest(offset, limit));
     return validationRuleMapper.mapEntitiesToValidationRuleCollection(validationRuleList);
   }
 

--- a/src/test/java/org/folio/pv/service/ValidationRuleServiceImplTest.java
+++ b/src/test/java/org/folio/pv/service/ValidationRuleServiceImplTest.java
@@ -96,7 +96,7 @@ public class ValidationRuleServiceImplTest {
     OffsetRequest offsetReq = new OffsetRequest(o, l);
     Page<PasswordValidationRule> rulePage = new PageImpl<>(rules);
 
-    when(repository.findByCQL(cql, offsetReq)).thenReturn(rulePage);
+    when(repository.findByCql(cql, offsetReq)).thenReturn(rulePage);
     when(mapper.mapEntitiesToValidationRuleCollection(rulePage)).thenReturn(ruleCollection);
 
     ValidationRuleCollection result = service.getValidationRules(o, l, cql);


### PR DESCRIPTION
## Purpose
_Migrate to folio-spring-support v7.0.0_

## Approach
_Increased version of folio-spring-base version from 6.0.1 to 7.0.0_
_Added dependecy folio-spring-cql v.7.0.0  &&  updated NEWS_
_Changed method from findByCQL to findByCql_

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [x] Interface versions changes
- [x] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.