### PR TITLE
MODPWD-118 Upgrade Folio spring base dependency version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @folio-org/spitfire-backend
+* @folio-org/volaris-backend

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <folio-spring-base.version>7.2.0</folio-spring-base.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
-    <hypersistence-utils.version>3.1.2</hypersistence-utils.version>
+    <hypersistence-utils.version>3.5.2</hypersistence-utils.version>
 
     <sonar.exclusions>
       src/main/java/org/folio/pv/domain/**,
@@ -93,7 +93,7 @@
     </dependency>
     <dependency>
       <groupId>io.hypersistence</groupId>
-      <artifactId>hypersistence-utils-hibernate-60</artifactId>
+      <artifactId>hypersistence-utils-hibernate-62</artifactId>
       <version>${hypersistence-utils.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.1.4</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <validator-registry.yaml.file>${project.basedir}/src/main/resources/swagger.api/validator-registry.yaml</validator-registry.yaml.file>
     <password-validator.yaml.file>${project.basedir}/src/main/resources/swagger.api/password-validator.yaml</password-validator.yaml.file>
 
-    <folio-spring-base.version>7.0.0</folio-spring-base.version>
+    <folio-spring-base.version>7.2.0</folio-spring-base.version>
     <mapstruct.version>1.5.3.Final</mapstruct.version>
     <hypersistence-utils.version>3.1.2</hypersistence-utils.version>
 

--- a/src/main/resources/db/changelog/changes/v1.9.0/create-old-validation-rules-table.xml
+++ b/src/main/resources/db/changelog/changes/v1.9.0/create-old-validation-rules-table.xml
@@ -31,7 +31,7 @@
         </preConditions>
 
         <sqlFile dbms="postgresql"
-                 path="v1.9.0/populate-initial-rules.sql"
+                 path="populate-initial-rules.sql"
                  relativeToChangelogFile="true"
                  splitStatements="false"/>
     </changeSet>


### PR DESCRIPTION
## Purpose
Upgrade Folio spring base dependency version and spring boot starter version

## Approach
Updated the version of folio-spring-base version to 7.2.0  and after updating the spring boot version, the integration test started to fail. After checking the below issue discussion, updated the hypersistence-utils version to hypersistence-utils-hibernate-62 from hypersistence-utils-hibernate-60. Then there is a problem with liquibase as it is appending path v1.09 automatically so removed the path which is there in create-old-validation-rules-table.xml file. Now the build and test are working fine.
https://github.com/vladmihalcea/hypersistence-utils/issues/519

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
