### PR TITLE
MODPWD-122 Missing interface dependencies in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -87,6 +87,10 @@
     {
       "id" : "users",
       "version" : "16.1"
+    },
+    {
+      "id" : "login",
+      "version" : "7.3"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
## Purpose
Purpose of the pr is - https://folio-org.atlassian.net/browse/MODPWD-122
## Approach
login dependency with version 7.3 is added in Module descriptor of mod-password-validator.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
