### PR TITLE
MODPWD-132: Remove non-empty validation from username

### DIFF
--- a/src/main/java/org/folio/pv/service/PasswordValidatorServiceImpl.java
+++ b/src/main/java/org/folio/pv/service/PasswordValidatorServiceImpl.java
@@ -44,8 +44,8 @@ public class PasswordValidatorServiceImpl implements PasswordValidatorService {
 
   @Override
   public ValidationResult checkPassword(String tenant, PasswordCheck passwordCheck) {
-    String username = passwordCheck.getUsername();
-    String password = passwordCheck.getPassword();
+    String username = passwordCheck.getUsername().trim();
+    String password = passwordCheck.getPassword().trim();
     UserData userData = new UserData();
     userData.setName(username);
     List<PasswordValidationRule> rules = getSortedRules(getPasswordCheckRules(tenant));

--- a/src/main/resources/swagger.api/schemas/password_check.json
+++ b/src/main/resources/swagger.api/schemas/password_check.json
@@ -5,8 +5,7 @@
   "properties": {
     "username": {
       "type": "string",
-      "description": "Username",
-      "x-field-extra-annotation": "@jakarta.validation.constraints.NotEmpty(message = \"username.empty\")"
+      "description": "Username"
     },
     "password": {
       "type": "string",

--- a/src/test/java/org/folio/pv/api/PasswordValidatorControllerIT.java
+++ b/src/test/java/org/folio/pv/api/PasswordValidatorControllerIT.java
@@ -104,7 +104,18 @@ class PasswordValidatorControllerIT extends BaseApiTest {
 
   @Test
   void checkPassword_fail_whenEmptyUsername() {
+    mockGet("/range/.*", "0018A45C4D1DEF81644B54AB7F969B88D65:0", SC_OK, TEXT_PLAIN_VALUE, wireMockServer);
     var password = new PasswordCheck().password("7Xu^&t[:J3Hha(<B").username("");
+
+    var validationResult = verifyPost(PASSWORD_CHECK_PATH, password, SC_OK).as(ValidationResult.class);
+
+    assertThat(validationResult).hasFieldOrPropertyWithValue("result", "invalid");
+    assertEquals("password.usernameDuplicate.invalid", validationResult.getMessages().get(0));
+  }
+
+  @Test
+  void checkPassword_fail_whenNullUsername() {
+    var password = new PasswordCheck().password("7Xu^&t[:J3Hha(<B");
 
     Errors errors = verifyPost(PASSWORD_CHECK_PATH, password, SC_UNPROCESSABLE_ENTITY).as(Errors.class);
 


### PR DESCRIPTION
## Purpose
Update /password/check endpoint to skip not empty validation for username to provide better UX and correct behavior. 

## Approach
- Remove non-empty username validation on /password/check

### Changes checklist
- [x] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

### Visuals
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/96945b68-a8bc-4762-a7bb-b33316165177" />

