### PR TITLE
MODPWD-133: [Password validation] Some special chars breaking regex validation rule for matching against password from the user_name

### DIFF
--- a/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
+++ b/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
@@ -25,12 +25,15 @@ public class RegExpValidator implements Validator {
 
     var failed = false;
     if (isNotBlank(expression)) {
-      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, user.getName());
+      String passwordWithoutSpaces = password.replaceAll("\\s", "");
+      String usernameWithoutSpaces = user.getName().replaceAll("\\s", "");
+
+      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, usernameWithoutSpaces);
       log.info("Validating password against regexp: {}", exprWithUser);
 
       var pattern = Pattern.compile(exprWithUser);
 
-      failed = !pattern.matcher(password).matches();
+      failed = !pattern.matcher(passwordWithoutSpaces).matches();
     }
 
     if (failed) {

--- a/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
+++ b/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
@@ -25,8 +25,8 @@ public class RegExpValidator implements Validator {
 
     var failed = false;
     if (isNotBlank(expression)) {
-      String passwordWithoutSpaces = password.replaceAll("\\s", "");
-      String usernameWithoutSpaces = user.getName().replaceAll("\\s", "");
+      var passwordWithoutSpaces = password.replaceAll("\\s", "");
+      var usernameWithoutSpaces = user.getName().replaceAll("\\s", "");
 
       var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, usernameWithoutSpaces);
       log.info("Validating password against regexp: {}", exprWithUser);

--- a/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
+++ b/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
@@ -85,7 +85,6 @@ class RegExpValidatorTest {
 
   @Test
   void shouldReturnErrorWithMessageIdIfNoMatchForSpace() {
-    //rule.setRuleExpression("^(?:(?!<USER_NAME>).)+$");
     rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
 
     String password = "Us ername3.";
@@ -100,7 +99,6 @@ class RegExpValidatorTest {
 
   @Test
   void shouldReturnErrorWithMessageIdIfNoMatchForUpperAndLowerCase() {
-    //rule.setRuleExpression("^(?:(?!<USER_NAME>).)+$");
     rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
 
     String password = "USername3.";

--- a/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
+++ b/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
@@ -82,4 +82,34 @@ class RegExpValidatorTest {
       () -> assertThat(errors.getErrorMessages()).containsExactly(rule.getErrMessageId())
     );
   }
+
+  @Test
+  void shouldReturnErrorWithMessageIdIfNoMatchForSpace() {
+    //rule.setRuleExpression("^(?:(?!<USER_NAME>).)+$");
+    rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
+
+    String password = "Us ername3.";
+    UserData user1Data = new UserData("1", "Username3.");
+    ValidationErrors errors = validator.validate(password, user1Data);
+
+    Assertions.assertAll(
+      () -> assertTrue(errors.hasErrors()),
+      () -> assertThat(errors.getErrorMessages()).containsExactly(rule.getErrMessageId())
+    );
+  }
+
+  @Test
+  void shouldReturnErrorWithMessageIdIfNoMatchForUpperAndLowerCase() {
+    //rule.setRuleExpression("^(?:(?!<USER_NAME>).)+$");
+    rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
+
+    String password = "USername3.";
+    UserData user1Data = new UserData("1", "Username3.");
+    ValidationErrors errors = validator.validate(password, user1Data);
+
+    Assertions.assertAll(
+      () -> assertTrue(errors.hasErrors()),
+      () -> assertThat(errors.getErrorMessages()).containsExactly(rule.getErrMessageId())
+    );
+  }
 }


### PR DESCRIPTION
## Approach
- When the values of either password or username contains space: exception password.usernameDuplicate.invalid not thrown
- When the values of either password or username contains uppercase or lowercase letters: exception password.usernameDuplicate.invalid not thrown

## Checklist
<!--
  This serves as gentle reminder for common tasks. Confirm these are done and check all that apply.
-->
- [ ] Documentation updated
- [x] Tests cover new or modified code
- [ ] New dependencies added
- [ ] Includes breaking changes
- [ ] Module permissions been updated when calling new APIs
- [ ] The interface version has been bumped
- [ ] Coordinated corresponding changes in the UI and other backend modules that consume new interface 

## It was
<img width="508" alt="image" src="https://github.com/user-attachments/assets/c1e9dfce-10f6-4b16-bfc3-9050eac7198e" />
<img width="523" alt="image" src="https://github.com/user-attachments/assets/1d9c4fc1-42c5-4f81-a99e-59b9b25cd21d" />

## Fixed
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/b49c3ddc-c603-4a24-ada6-1501dec047a5" />
<img width="666" alt="image" src="https://github.com/user-attachments/assets/fbe2aca2-ee59-44e7-ac6f-34c6a1a748ba" />

