### PR TITLE
FOLIO-3944 Upgrade Actions for API-related Workflows

### DIFF
--- a/.github/workflows/api-doc.yml
+++ b/.github/workflows/api-doc.yml
@@ -32,14 +32,16 @@ on:
     branches: [ main, master ]
     paths:
       - 'src/main/resources/swagger.api/**'
+      - 'descriptors/ModuleDescriptor-template.json'
     tags: '[vV][0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
 
 jobs:
   api-doc:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.REF }}
           submodules: recursive

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -33,13 +33,14 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Prepare folio-tools

--- a/.github/workflows/api-schema-lint.yml
+++ b/.github/workflows/api-schema-lint.yml
@@ -23,13 +23,14 @@ on:
   pull_request:
     paths:
       - 'src/main/resources/swagger.api/**'
+  workflow_dispatch:
 
 jobs:
   api-schema-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Prepare folio-tools


### PR DESCRIPTION
Use actions/checkout v4  and workflow_dispatch

Keep up-to-date with dependent GitHub Actions. [FOLIO-3944](https://issues.folio.org/browse/FOLIO-3944)