### PR TITLE
Re: MODPWD-133: [Password validation] Some special chars breaking regex validation rule for matching against password from the user_name

### DIFF
--- a/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
+++ b/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
@@ -3,7 +3,6 @@ package org.folio.pv.service.validator;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.regex.Pattern;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;

--- a/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
+++ b/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
@@ -3,6 +3,7 @@ package org.folio.pv.service.validator;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.regex.Pattern;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -22,18 +23,20 @@ public class RegExpValidator implements Validator {
   @Override
   public ValidationErrors validate(String password, UserData user) {
     var expression = rule.getRuleExpression();
-
+    var userName = user.getName();
     var failed = false;
     if (isNotBlank(expression)) {
-      var passwordWithoutSpaces = password.replaceAll("\\s", "");
-      var usernameWithoutSpaces = user.getName().replaceAll("\\s", "");
+      if (expression.contains(REGEXP_USER_NAME_PLACEHOLDER)) {
+        password = password.replaceAll("\\s", "");
+        userName = userName.replaceAll("\\s", "");
+      }
 
-      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, usernameWithoutSpaces);
+      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, userName);
       log.info("Validating password against regexp: {}", exprWithUser);
 
       var pattern = Pattern.compile(exprWithUser);
 
-      failed = !pattern.matcher(passwordWithoutSpaces).matches();
+      failed = !pattern.matcher(password).matches();
     }
 
     if (failed) {


### PR DESCRIPTION
## Purpose
Fix for older PR: Use the new approach for only validation against username with rule: "no_user_name"

https://folio-org.atlassian.net/browse/MODPWD-133?atlOrigin=eyJpIjoiNjAxY2VjZDJhMTNjNGMxNGFiY2Q5OTI4OTQ0NTFiZmQiLCJwIjoiaiJ9

