### PR TITLE
MODPWD-133: [Password validation] Password cannot contain space inside its value

### DIFF
--- a/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
+++ b/src/main/java/org/folio/pv/service/validator/RegExpValidator.java
@@ -25,15 +25,13 @@ public class RegExpValidator implements Validator {
 
     var failed = false;
     if (isNotBlank(expression)) {
-      var passwordWithoutSpaces = password.replaceAll("\\s", "");
-      var usernameWithoutSpaces = user.getName().replaceAll("\\s", "");
 
-      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, usernameWithoutSpaces);
+      var exprWithUser = expression.replace(REGEXP_USER_NAME_PLACEHOLDER, user.getName());
       log.info("Validating password against regexp: {}", exprWithUser);
 
       var pattern = Pattern.compile(exprWithUser);
 
-      failed = !pattern.matcher(passwordWithoutSpaces).matches();
+      failed = !pattern.matcher(password).matches();
     }
 
     if (failed) {

--- a/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
+++ b/src/test/java/org/folio/pv/service/validator/RegExpValidatorTest.java
@@ -84,10 +84,10 @@ class RegExpValidatorTest {
   }
 
   @Test
-  void shouldReturnErrorWithMessageIdIfNoMatchForSpace() {
+  void shouldReturnErrorWithMessageIdIfNoMatchForUpperAndLowerCase() {
     rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
 
-    String password = "Us ername3.";
+    String password = "USername3.";
     UserData user1Data = new UserData("1", "Username3.");
     ValidationErrors errors = validator.validate(password, user1Data);
 
@@ -98,10 +98,24 @@ class RegExpValidatorTest {
   }
 
   @Test
-  void shouldReturnErrorWithMessageIdIfNoMatchForUpperAndLowerCase() {
-    rule.setRuleExpression("^(?i)(?:(?!<USER_NAME>).)+$");
+  void shouldReturnErrorWithMessageIdIfPasswordContainsConsecutiveWhitespaces() {
+    rule.setRuleExpression("^(?:(?!\\s{2,}).)+$");
 
-    String password = "USername3.";
+    String password = "Test  Model  123@#";
+    UserData user1Data = new UserData("1", "Username3.");
+    ValidationErrors errors = validator.validate(password, user1Data);
+
+    Assertions.assertAll(
+      () -> assertTrue(errors.hasErrors()),
+      () -> assertThat(errors.getErrorMessages()).containsExactly(rule.getErrMessageId())
+    );
+  }
+
+  @Test
+  void shouldReturnErrorWithMessageIdIfPasswordContainsWhitespaces() {
+    rule.setRuleExpression("[^\\s]+");
+
+    String password = "Test Model123@#";
     UserData user1Data = new UserData("1", "Username3.");
     ValidationErrors errors = validator.validate(password, user1Data);
 


### PR DESCRIPTION
## Purpose
Fix for older PR: Use the new approach for only validation against username with rule: "no_user_name"

https://folio-org.atlassian.net/browse/MODPWD-133?atlOrigin=eyJpIjoiNjAxY2VjZDJhMTNjNGMxNGFiY2Q5OTI4OTQ0NTFiZmQiLCJwIjoiaiJ9

